### PR TITLE
Util.h parallel error fix

### DIFF
--- a/lib/mmseqs/src/commons/Util.h
+++ b/lib/mmseqs/src/commons/Util.h
@@ -9,9 +9,19 @@
 #include <map>
 #include "MMseqsMPI.h"
 
+#include <mutex>
+
 #ifndef EXIT
-#define EXIT(exitCode) do { int __status = (exitCode); std::cerr.flush(); std::cout.flush(); exit(__status); } while(0)
+#define EXIT(exitCode) do { \
+    static std::mutex exitMutex; \
+    std::lock_guard<std::mutex> lock(exitMutex); \
+    int __status = (exitCode); \
+    std::cerr.flush(); \
+    std::cout.flush(); \
+    exit(__status); \
+} while(0)
 #endif
+
 
 #define BIT_SET(a,b) ((a) | (1ULL<<(b)))
 #define BIT_CLEAR(a,b) ((a) & ~(1ULL<<(b)))


### PR DESCRIPTION
Error while running make command
Was Working with Linux Subsystem for windows 
Version Details:
Distributor ID: Ubuntu
Description:    Ubuntu 22.04.2 LTS
Release:        22.04
Codename:       jammy

Error Screenshot : https://ibb.co/8gnqKDB

Fixed Errors:
Error1: foldseek/lib/mmseqs/src/commons/Util.h:13:71: error: ‘cerr’ not specified in enclosing ‘parallel’
   13 | #define EXIT(exitCode) do { int __status = (exitCode); std::cerr.flush(); std::cout.flush(); exit(__status); } while(0)
Error2: foldseek/lib/mmseqs/src/commons/Util.h:13:90: error: ‘cout’ not specified in enclosing ‘parallel’
   13 | #define EXIT(exitCode) do { int __status = (exitCode); std::cerr.flush(); std::cout.flush(); exit(__status); } while(0)