### PR TITLE
createsubdb works with list like 0\n1\n0\n2

### DIFF
--- a/data/createstructsubdb.sh
+++ b/data/createstructsubdb.sh
@@ -4,17 +4,26 @@ if [ -e "${IN}.dbtype" ]; then
     # shellcheck disable=SC2086
     "$MMSEQS" base:createsubdb "${LIST}" "${IN}" "${OUT}" ${CREATESTRUCTSUBDB1_PAR} \
         || fail "createsubdb died"
+    sort -nk2 "${OUT}.index" > "${OUT}.indextmp"
 fi
+
+
 
 if [ -e "${IN}_ss.dbtype" ]; then
     # shellcheck disable=SC2086
-    "$MMSEQS" base:createsubdb "${OUT}.index" "${IN}_ss" "${OUT}_ss" ${CREATESTRUCTSUBDB2_PAR} \
+    "$MMSEQS" base:createsubdb "${OUT}.indextmp" "${IN}_ss" "${OUT}_ss" ${CREATESTRUCTSUBDB2_PAR} \
         || fail "createsubdb died"
 fi
 
 if [ -e "${IN}_ca.dbtype" ]; then
     # shellcheck disable=SC2086
-    "$MMSEQS" base:createsubdb "${OUT}.index" "${IN}_ca" "${OUT}_ca" ${CREATESTRUCTSUBDB2_PAR} \
+    "$MMSEQS" base:createsubdb "${OUT}.indextmp" "${IN}_ca" "${OUT}_ca" ${CREATESTRUCTSUBDB2_PAR} \
+        || fail "createsubdb died"
+fi
+
+if [ -e "${IN}_id.dbtype" ]; then
+    # shellcheck disable=SC2086
+    "$MMSEQS" base:createsubdb "${OUT}.indextmp""${IN}_id" "${OUT}_id" ${CREATESTRUCTSUBDB_PAR} \
         || fail "createsubdb died"
 fi
 
@@ -26,4 +35,5 @@ fi
 
 if [ -e "${OUT}.sh" ]; then
   rm -f -- "${OUT}.sh"
+  rm "${OUT}.indextmp"
 fi


### PR DESCRIPTION
In the previous code, after first `mmseqs createsubdb list in out`, the out.index file is sorted by the first column.
If someone wants to create a subdb with a list like 0\n1\n0\n2\n0\n3, sorting out.index by the second column and using it as input for the subsequent createsubdb commands will work.