### PR TITLE
Add hash-based entry names and pathmap support for preserving full file paths

### DIFF
--- a/src/commons/CMakeLists.txt
+++ b/src/commons/CMakeLists.txt
@@ -4,6 +4,8 @@ set(commons_source_files
         commons/LDDT.cpp
         commons/LocalParameters.h
         commons/LocalParameters.cpp
+        commons/PathHasher.h
+        commons/PathHasher.cpp
         commons/StructureUtil.h
         commons/TMaligner.cpp
         commons/TMaligner.h

--- a/src/commons/LocalParameters.cpp
+++ b/src/commons/LocalParameters.cpp
@@ -40,7 +40,9 @@ LocalParameters::LocalParameters() :
         PARAM_MULTIMER_TM_THRESHOLD(PARAM_MULTIMER_TM_THRESHOLD_ID,"--multimer-tm-threshold", "TMscore threshold for filtermultimer", "accept alignments with a tmsore > thr [0.0,1.0]",typeid(float), (void *) &filtMultimerTmThr, "^0(\\.[0-9]+)?|1(\\.0+)?$"),
         PARAM_CHAIN_TM_THRESHOLD(PARAM_CHAIN_TM_THRESHOLD_ID,"--chain-tm-threshold", "chain TMscore threshold for filtermultimer", "accept alignments with a tmsore > thr [0.0,1.0]",typeid(float), (void *) &filtChainTmThr, "^0(\\.[0-9]+)?|1(\\.0+)?$"),
         PARAM_INTERFACE_LDDT_THRESHOLD(PARAM_INTERFACE_LDDT_THRESHOLD_ID,"--interface-lddt-threshold", "Interface LDDT threshold", "accept alignments with a lddt > thr [0.0,1.0]",typeid(float), (void *) &filtInterfaceLddtThr, "^0(\\.[0-9]+)?|1(\\.0+)?$"),
-        PARAM_MULTIDOMAIN(PARAM_MULTIDOMAIN_ID, "--multidomain", "MultiDomain Mode", "MultiDomain Mode LoLalign", typeid(int), (void *) &multiDomain, "^[0-1]{1}$")
+        PARAM_MULTIDOMAIN(PARAM_MULTIDOMAIN_ID, "--multidomain", "MultiDomain Mode", "MultiDomain Mode LoLalign", typeid(int), (void *) &multiDomain, "^[0-1]{1}$"),
+        PARAM_HASH_ENTRY_NAMES(PARAM_HASH_ENTRY_NAMES_ID, "--hash-entry-names", "Hash entry names", "Use hash-based entry names from full paths:\n0: use basename (default)\n1: hash full path to base62", typeid(int), (void *) &hashEntryNames, "^[0-1]{1}$", MMseqsParameter::COMMAND_EXPERT),
+        PARAM_PATHMAP(PARAM_PATHMAP_ID, "--pathmap", "Path mapping file", "Path mapping file to replace hashed IDs with full paths in results", typeid(std::string), (void *) &pathmapFile, "^.*$")
         {
     PARAM_ALIGNMENT_MODE.description = "How to compute the alignment:\n0: automatic\n1: only score and end_pos\n2: also start_pos and cov\n3: also seq.id";
     PARAM_ALIGNMENT_MODE.regex = "^[0-3]{1}$";
@@ -97,6 +99,7 @@ LocalParameters::LocalParameters() :
     structurecreatedb.push_back(&PARAM_COORD_STORE_MODE);
     structurecreatedb.push_back(&PARAM_WRITE_LOOKUP);
     structurecreatedb.push_back(&PARAM_INPUT_FORMAT);
+    structurecreatedb.push_back(&PARAM_HASH_ENTRY_NAMES);
     // protein chain only
     structurecreatedb.push_back(&PARAM_FILE_INCLUDE);
     structurecreatedb.push_back(&PARAM_FILE_EXCLUDE);
@@ -104,6 +107,7 @@ LocalParameters::LocalParameters() :
     structurecreatedb.push_back(&PARAM_V);
 
     convertalignments.push_back(&PARAM_EXACT_TMSCORE);
+    convertalignments.push_back(&PARAM_PATHMAP);
 
     createindex.push_back(&PARAM_INDEX_EXCLUDE);
 
@@ -325,6 +329,8 @@ LocalParameters::LocalParameters() :
     fileExclude = "^$";
     prostt5SplitLength = 1024;
     prostt5Model = "";
+    hashEntryNames = 0;
+    pathmapFile = "";
 
     // search parameter
     alignmentType = ALIGNMENT_TYPE_3DI_AA;

--- a/src/commons/LocalParameters.h
+++ b/src/commons/LocalParameters.h
@@ -159,6 +159,8 @@ public:
     PARAMETER(PARAM_CHAIN_TM_THRESHOLD)
     PARAMETER(PARAM_INTERFACE_LDDT_THRESHOLD)
     PARAMETER(PARAM_MULTIDOMAIN)
+    PARAMETER(PARAM_HASH_ENTRY_NAMES)
+    PARAMETER(PARAM_PATHMAP)
 
     float tmScoreThr;
     int tmScoreThrMode;
@@ -192,6 +194,8 @@ public:
     float distanceThreshold;
     int prostt5SplitLength;
     int multiDomain;
+    int hashEntryNames;
+    std::string pathmapFile;
 
     static std::vector<int> getOutputFormat(
         int formatMode, const std::string &outformat, bool &needSequences, bool &need3Di, bool &needBacktrace, bool &needFullHeaders,

--- a/src/commons/PathHasher.cpp
+++ b/src/commons/PathHasher.cpp
@@ -1,0 +1,28 @@
+#include "PathHasher.h"
+#include <functional>
+
+const char PathHasher::BASE62_ALPHABET[] =
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+std::string PathHasher::hashToBase62(uint64_t hash) {
+    if (hash == 0) {
+        return "0";
+    }
+
+    std::string result;
+    result.reserve(11); // max length for 64-bit number in base62
+
+    while (hash > 0) {
+        result = BASE62_ALPHABET[hash % BASE62_BASE] + result;
+        hash /= BASE62_BASE;
+    }
+
+    return result;
+}
+
+std::string PathHasher::hashPath(const std::string& path) {
+    // Use std::hash for a simple, fast hash function
+    std::hash<std::string> hasher;
+    uint64_t hash = hasher(path);
+    return hashToBase62(hash);
+}

--- a/src/commons/PathHasher.h
+++ b/src/commons/PathHasher.h
@@ -1,0 +1,20 @@
+#ifndef PATHHASHER_H
+#define PATHHASHER_H
+
+#include <string>
+#include <cstdint>
+
+class PathHasher {
+public:
+    // Encodes a 64-bit hash to base62 string (alphanumeric only)
+    static std::string hashToBase62(uint64_t hash);
+
+    // Hashes a full path string and returns base62 encoded hash
+    static std::string hashPath(const std::string& path);
+
+private:
+    static const char BASE62_ALPHABET[];
+    static const int BASE62_BASE = 62;
+};
+
+#endif // PATHHASHER_H


### PR DESCRIPTION
## Summary

This PR implements a solution for handling PDB files with duplicate basenames across different directories:

- **--hash-entry-names**: Hash full file paths to base62 alphanumeric IDs to prevent collisions
- **--pathmap**: Optional parameter to automatically replace hashed IDs with full paths in search results

## Changes

- Added `PathHasher` utility for base62 encoding
- Added `--hash-entry-names` parameter to `createdb`
- Added `--pathmap` parameter to `easy-search`/`convertalis`
- Automatic `.pathmap` file generation during database creation
- Automatic ID replacement in results when pathmap is provided

## Testing

Tested with duplicate PDB basenames:
- Database creation with `--hash-entry-names 1` generates hashed IDs
- Search without `--pathmap` shows hashed IDs
- Search with `--pathmap` correctly resolves to full paths
- Backward compatibility maintained (both parameters optional)

## Files Changed

- `src/commons/PathHasher.h` (NEW): Hash utility header
- `src/commons/PathHasher.cpp` (NEW): Base62 encoding implementation
- `src/commons/LocalParameters.h`: Added new parameters
- `src/commons/LocalParameters.cpp`: Parameter initialization
- `src/commons/CMakeLists.txt`: Added PathHasher to build
- `src/strucclustutils/structcreatedb.cpp`: Hash-based ID generation and pathmap creation
- `src/strucclustutils/structureconvertalis.cpp`: Pathmap resolution in results

🤖 Generated with [Claude Code](https://claude.com/claude-code)