### PR TITLE
Add structureclusterupdate workflow

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -3,6 +3,7 @@ include(MMseqsResourceCompiler)
 set(COMPILED_RESOURCES
         easystructuresearch.sh
         structurecluster.sh
+        structureclusterupdate.sh
         structureindex.sh
         structuresearch.sh
         structureiterativesearch.sh

--- a/data/structureclusterupdate.sh
+++ b/data/structureclusterupdate.sh
@@ -1,0 +1,314 @@
+#!/bin/sh -e
+
+fail() {
+    echo "Error: $1"
+    exit 1
+}
+
+notExists() {
+    [ ! -f "$1" ]
+}
+
+abspath() {
+    if [ -d "$1" ]; then
+        (cd "$1"; pwd)
+    elif [ -f "$1" ]; then
+        if [ -z "${1##*/*}" ]; then
+            echo "$(cd "${1%/*}"; pwd)/${1##*/}"
+        else
+            echo "$(pwd)/$1"
+        fi
+    elif [ -d "$(dirname "$1")" ]; then
+        echo "$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
+    fi
+}
+
+log() {
+    if [ "${VERBOSITY}" = "-v 3" ]; then
+        echo "$@"
+    fi
+}
+
+# check number of input variables
+[ "$#" -ne 6 ] && echo "Please provide <i:oldSequenceDB> <i:newSequenceDB> <i:oldClusteringDB> <o:newMappedSequenceDB> <o:newClusteringDB> <o:tmpDir>" && exit 1
+# check if files exist
+[ ! -f "$1.dbtype" ] && echo "$1.dbtype not found!" && exit 1
+[ ! -f "$2.dbtype" ] && echo "$2.dbtype not found!" && exit 1
+[ ! -f "$3.dbtype" ] && echo "$3.dbtype not found!" && exit 1
+[   -f "$5.dbtype" ] && echo "$5.dbtype exists already!" && exit 1
+[ ! -d "$6" ] && echo "tmp directory $6 not found!" && exit 1
+
+OLDDB="$(abspath "$1")"
+NEWDB="$(abspath "$2")"
+OLDCLUST="$(abspath "$3")"
+NEWMAPDB="$(abspath "$4")"
+NEWCLUST="$(abspath "$5")"
+TMP_PATH="$(abspath "$6")"
+
+if notExists "${TMP_PATH}/removedSeqs"; then
+    # shellcheck disable=SC2086
+    "$MMSEQS" diffseqdbs "$OLDDB" "$NEWDB" "${TMP_PATH}/removedSeqs" "${TMP_PATH}/mappingSeqs" "${TMP_PATH}/newSeqs" ${DIFF_PAR} \
+        || fail "Diff died"
+fi
+
+if [ ! -s "${TMP_PATH}/mappingSeqs" ]; then
+    cat <<WARN
+WARNING: There are no common sequences between $OLDDB and $NEWDB.
+If you aim to add the sequences of $NEWDB to your previous clustering $OLDCLUST, you can run:
+
+foldseek concatdbs "$OLDDB" "$NEWDB" "${OLDDB}.withNewSequences"
+foldseek concatdbs "${OLDDB}_h" "${NEWDB}_h" "${OLDDB}.withNewSequences_h"
+foldseek structureclusterupdate "$OLDDB" "${OLDDB}.withNewSequences" "$OLDCLUST" newMappedDB "$NEWCLUST" "${TMP_PATH}"
+WARN
+    rm -f "${TMP_PATH}/removedSeqs" "${TMP_PATH}/mappingSeqs" "${TMP_PATH}/newSeqs"
+    exit 1
+fi
+
+if [ -s "${TMP_PATH}/removedSeqs" ]; then
+    if [ -n "${RECOVER_DELETED}" ]; then
+        log "=== Recover removed sequences"
+        if notExists "${TMP_PATH}/OLDDB.removedMapping"; then
+            HIGHESTID="$(awk '$1 > max { max = $1 } END { print max }' "${NEWDB}.index")"
+            awk -v highest="$HIGHESTID" 'BEGIN { start=highest+1 } { printf("%s\t%.0f\n", $1, start); start=start+1; }' \
+                "${TMP_PATH}/removedSeqs" > "${TMP_PATH}/OLDDB.removedMapping"
+            cat "${TMP_PATH}/OLDDB.removedMapping" >> "${TMP_PATH}/mappingSeqs"
+        fi
+
+        if notExists "${TMP_PATH}/NEWDB.withOld.dbtype"; then
+            # shellcheck disable=SC2086
+            "$MMSEQS" renamedbkeys "${TMP_PATH}/OLDDB.removedMapping" "${OLDDB}" "${TMP_PATH}/OLDDB.removedDb" --subdb-mode 1 ${VERBOSITY} \
+                || fail "renamedbkeys died"
+            # shellcheck disable=SC2086
+            "$MMSEQS" concatdbs "$NEWDB" "${TMP_PATH}/OLDDB.removedDb" "${TMP_PATH}/NEWDB.withOld" --preserve-keys --threads 1 ${VERBOSITY} \
+                || fail "concatdbs died"
+            # shellcheck disable=SC2086
+            "$MMSEQS" concatdbs "${NEWDB}_h" "${TMP_PATH}/OLDDB.removedDb_h" "${TMP_PATH}/NEWDB.withOld_h" --preserve-keys --threads 1 ${VERBOSITY} \
+                || fail "concatdbs died"
+        fi
+        NEWDB="${TMP_PATH}/NEWDB.withOld"
+
+        if [ -n "$REMOVE_TMP" ]; then
+            echo "Remove temporary files 1/3"
+            rm -f "${TMP_PATH}/OLDDB.removedMapping"
+            # shellcheck disable=SC2086
+            "$MMSEQS" rmdb "${TMP_PATH}/OLDDB.removedDb" ${VERBOSITY}
+        fi
+    else
+        if notExists "${TMP_PATH}/REMOVEDMEMBERS.dbtype"; then
+            # shellcheck disable=SC2086
+            "$MMSEQS" createsubdb "${TMP_PATH}/removedSeqs" "${OLDCLUST}" "${TMP_PATH}/REMOVEDMEMBERS" --subdb-mode 0 ${NOWARNINGS_PAR} \
+                || fail "createsubdb died"
+        fi
+
+        if notExists "${TMP_PATH}/REMOVEDMEMBERS.withoutDeleted.dbtype"; then
+            # shellcheck disable=SC2086
+            "$MMSEQS" filterdb "${TMP_PATH}/REMOVEDMEMBERS" "${TMP_PATH}/REMOVEDMEMBERS.withoutDeleted" --filter-file "${TMP_PATH}/removedSeqs" --positive-filter ${THREADS_PAR} \
+                || fail "filterdb died"
+        fi
+
+        if notExists "${TMP_PATH}/REMOVEDMEMBERS.tsv"; then
+            # shellcheck disable=SC2086
+            "$MMSEQS" prefixid "${TMP_PATH}/REMOVEDMEMBERS.withoutDeleted" "${TMP_PATH}/REMOVEDMEMBERS.withoutDeleted.tsv" --tsv ${VERBOSITY} \
+                || fail "prefixid died"
+            awk '{ print $2; }' "${TMP_PATH}/REMOVEDMEMBERS.withoutDeleted.tsv" > "${TMP_PATH}/REMOVEDMEMBERS.tsv"
+        fi
+
+        if notExists "${TMP_PATH}/OLCLUST.withoutDeletedKeys.dbtype"; then
+            # shellcheck disable=SC2086
+            "$MMSEQS" createsubdb "${TMP_PATH}/mappingSeqs" "${OLDCLUST}" "${TMP_PATH}/OLCLUST.withoutDeletedKeys" --subdb-mode 1 ${NOWARNINGS_PAR} \
+                || fail "createsubdb died"
+        fi
+
+        if notExists "${TMP_PATH}/OLCLUST.withoutDeleted.dbtype"; then
+            # shellcheck disable=SC2086
+            "$MMSEQS" filterdb "${TMP_PATH}/OLCLUST.withoutDeletedKeys" "${TMP_PATH}/OLCLUST.withoutDeleted" --filter-file "${TMP_PATH}/removedSeqs" --positive-filter ${THREADS_PAR} \
+                || fail "filterdb died"
+        fi
+        OLDCLUST="${TMP_PATH}/OLCLUST.withoutDeleted"
+    fi
+fi
+
+if notExists "${TMP_PATH}/newMappingSeqs"; then
+    log "=== Update new sequences with old keys"
+    MAXID="$(awk '$1 > max { max = $1 } END { print max }' "${OLDDB}.index" "${NEWDB}.index")"
+    awk -v highest="$MAXID" 'BEGIN { start=highest+1 } { printf("%s\t%.0f\n", $1, start); start=start+1; }' \
+        "${TMP_PATH}/newSeqs" > "${TMP_PATH}/newSeqs.mapped"
+    awk '{ print $2"\t"$1 }' "${TMP_PATH}/mappingSeqs" > "${TMP_PATH}/mappingSeqs.reverse"
+    cat "${TMP_PATH}/mappingSeqs.reverse" "${TMP_PATH}/newSeqs.mapped" > "${TMP_PATH}/newMappingSeqs"
+    awk '{ print $2 }' "${TMP_PATH}/newSeqs.mapped" > "${TMP_PATH}/newSeqs"
+fi
+
+if notExists "${NEWMAPDB}.dbtype"; then
+    # shellcheck disable=SC2086
+    "$MMSEQS" renamedbkeys "${TMP_PATH}/newMappingSeqs" "${NEWDB}" "${NEWMAPDB}" ${VERBOSITY} \
+        || fail "renamedbkeys died"
+fi
+if [ -f "${NEWDB}_ss.dbtype" ] && notExists "${NEWMAPDB}_ss.dbtype"; then
+    # shellcheck disable=SC2086
+    "$MMSEQS" renamedbkeys "${TMP_PATH}/newMappingSeqs" "${NEWDB}_ss" "${NEWMAPDB}_ss" ${VERBOSITY} \
+        || fail "renamedbkeys for 3Di died"
+fi
+if [ -f "${NEWDB}_h.dbtype" ] && notExists "${NEWMAPDB}_h.dbtype"; then
+    # shellcheck disable=SC2086
+    "$MMSEQS" renamedbkeys "${TMP_PATH}/newMappingSeqs" "${NEWDB}_h" "${NEWMAPDB}_h" ${VERBOSITY} \
+        || fail "renamedbkeys for headers died"
+fi
+NEWDB="${NEWMAPDB}"
+
+NEWSEQ="${TMP_PATH}/newSeqs"
+if [ -s "${TMP_PATH}/removedSeqs" ] && [ -z "${RECOVER_DELETED}" ]; then
+    cat "${TMP_PATH}/REMOVEDMEMBERS.tsv" "${TMP_PATH}/newSeqs" > "${TMP_PATH}/newSeqs.withMembers"
+    NEWSEQ="${TMP_PATH}/newSeqs.withMembers"
+fi
+
+if notExists "${TMP_PATH}/NEWDB.newSeqs.dbtype"; then
+    log "=== Filter out new from old sequences"
+    # shellcheck disable=SC2086
+    "$MMSEQS" createsubdb "${NEWSEQ}" "$NEWDB" "${TMP_PATH}/NEWDB.newSeqs" ${VERBOSITY} --subdb-mode 1 \
+        || fail "createsubdb died"
+fi
+
+if [ -f "${NEWDB}_ss.dbtype" ] && notExists "${TMP_PATH}/NEWDB.newSeqs_ss.dbtype"; then
+    log "=== Filter out new from old 3Di sequences"
+    # shellcheck disable=SC2086
+    "$MMSEQS" createsubdb "${NEWSEQ}" "${NEWDB}_ss" "${TMP_PATH}/NEWDB.newSeqs_ss" ${VERBOSITY} --subdb-mode 1 \
+        || fail "createsubdb for 3Di died"
+fi
+
+if notExists "${TMP_PATH}/OLDDB.repSeq.dbtype"; then
+    log "=== Extract representative AA sequences"
+    # Use createsubdb (not result2repseq): afdb50_clu members are keyed on afdb50_seq (241M),
+    # but afdb50 only contains the 66M cluster reps. createsubdb uses the index keys directly.
+    # shellcheck disable=SC2086
+    "$MMSEQS" createsubdb "$OLDCLUST" "$OLDDB" "${TMP_PATH}/OLDDB.repSeq" --subdb-mode 1 ${VERBOSITY} \
+        || fail "createsubdb for rep AA sequences died"
+fi
+
+if [ -f "${OLDDB}_ss.dbtype" ] && notExists "${TMP_PATH}/OLDDB.repSeq_ss.dbtype"; then
+    log "=== Extract representative 3Di sequences"
+    # shellcheck disable=SC2086
+    "$MMSEQS" createsubdb "$OLDCLUST" "${OLDDB}_ss" "${TMP_PATH}/OLDDB.repSeq_ss" --subdb-mode 1 ${VERBOSITY} \
+        || fail "createsubdb for rep 3Di sequences died"
+fi
+
+if notExists "${TMP_PATH}/newSeqsPref.dbtype"; then
+    log "=== Prefilter new sequences against cluster representatives"
+    # shellcheck disable=SC2086
+    $RUNNER "$MMSEQS" prefilter "${TMP_PATH}/NEWDB.newSeqs" "${TMP_PATH}/OLDDB.repSeq" \
+        "${TMP_PATH}/newSeqsPref" ${PREFILTER_PAR} \
+        || fail "Prefilter died"
+fi
+
+if notExists "${TMP_PATH}/newSeqsHits.dbtype"; then
+    log "=== Structurally align new sequences against cluster representatives"
+    # shellcheck disable=SC2086
+    $RUNNER "$MMSEQS" $ALIGNMENT_ALGO "${TMP_PATH}/NEWDB.newSeqs" "${TMP_PATH}/OLDDB.repSeq" \
+        "${TMP_PATH}/newSeqsPref" "${TMP_PATH}/newSeqsHits" ${ALIGNMENT_PAR} \
+        || fail "Structural alignment died"
+fi
+
+if notExists "${TMP_PATH}/newSeqsHits.best.dbtype"; then
+    log "=== Keep best rep per new sequence (prevents one sequence joining multiple clusters)"
+    # shellcheck disable=SC2086
+    "$MMSEQS" filterdb "${TMP_PATH}/newSeqsHits" "${TMP_PATH}/newSeqsHits.best" \
+        --extract-lines 1 ${THREADS_PAR} \
+        || fail "filterdb best-hit died"
+fi
+
+if notExists "${TMP_PATH}/newSeqsHits.swapped.all.dbtype"; then
+    # shellcheck disable=SC2086
+    "$MMSEQS" swapdb "${TMP_PATH}/newSeqsHits.best" "${TMP_PATH}/newSeqsHits.swapped.all" ${THREADS_PAR} \
+        || fail "swapdb died"
+    awk '$3 > 1 { print 1; exit; }' "${TMP_PATH}/newSeqsHits.swapped.all.index" > "${TMP_PATH}/newSeqsHits.swapped.hasHits"
+fi
+
+if [ -s "${TMP_PATH}/newSeqsHits.swapped.hasHits" ] && notExists "${TMP_PATH}/newSeqsHits.swapped.dbtype"; then
+    # shellcheck disable=SC2086
+    "$MMSEQS" filterdb "${TMP_PATH}/newSeqsHits.swapped.all" "${TMP_PATH}/newSeqsHits.swapped" --trim-to-one-column ${THREADS_PAR} \
+        || fail "filterdb died"
+fi
+
+UPDATEDCLUST="${TMP_PATH}/updatedClust"
+if [ -f "${TMP_PATH}/newSeqsHits.swapped.dbtype" ]; then
+    if notExists "${TMP_PATH}/updatedClust.dbtype"; then
+        log "=== Merge structurally assigned sequences with previous clustering"
+        # shellcheck disable=SC2086
+        "$MMSEQS" mergedbs "$OLDCLUST" "${TMP_PATH}/updatedClust" "$OLDCLUST" "${TMP_PATH}/newSeqsHits.swapped" ${VERBOSITY} \
+            || fail "mergedbs died"
+    fi
+else
+    UPDATEDCLUST="$OLDCLUST"
+fi
+
+if notExists "${TMP_PATH}/toBeClusteredSeparately.dbtype"; then
+    log "=== Extract unmapped sequences for independent clustering"
+    awk '$3 == 1 {print $1}' "${TMP_PATH}/newSeqsHits.index" > "${TMP_PATH}/noHitSeqList"
+    # shellcheck disable=SC2086
+    "$MMSEQS" createsubdb "${TMP_PATH}/noHitSeqList" "$NEWDB" "${TMP_PATH}/toBeClusteredSeparately" ${VERBOSITY} --subdb-mode 1 \
+        || fail "createsubdb of not hit seq. died"
+fi
+
+if notExists "${TMP_PATH}/newClusters.dbtype" && [ -s "${TMP_PATH}/toBeClusteredSeparately.index" ]; then
+    log "=== Cluster unmapped sequences"
+    # shellcheck disable=SC2086
+    "$MMSEQS" cluster "${TMP_PATH}/toBeClusteredSeparately" "${TMP_PATH}/newClusters" "${TMP_PATH}/cluster" ${CLUST_PAR} \
+        || fail "cluster of new seq. died"
+fi
+
+if [ -f "${TMP_PATH}/newClusters.dbtype" ]; then
+    if notExists "$NEWCLUST"; then
+        log "=== Merge updated clustering with new clusters"
+        # shellcheck disable=SC2086
+        "$MMSEQS" concatdbs "${UPDATEDCLUST}" "${TMP_PATH}/newClusters" "$NEWCLUST" --preserve-keys ${THREADS_PAR} \
+            || fail "concatdbs died"
+    fi
+else
+    # shellcheck disable=SC2086
+    "$MMSEQS" mvdb "${UPDATEDCLUST}" "$NEWCLUST" ${VERBOSITY}
+fi
+
+if [ -n "$REMOVE_TMP" ]; then
+    rm -f "${TMP_PATH}/newSeqs.mapped" "${TMP_PATH}/mappingSeqs.reverse" "${TMP_PATH}/newMappingSeqs"
+    rm -f "${TMP_PATH}/noHitSeqList" "${TMP_PATH}/mappingSeqs" "${TMP_PATH}/newSeqs" "${TMP_PATH}/removedSeqs"
+    rm -f "${TMP_PATH}/newSeqsHits.swapped.hasHits"
+
+    if [ -n "${RECOVER_DELETED}" ]; then
+        # shellcheck disable=SC2086
+        "$MMSEQS" rmdb "${TMP_PATH}/NEWDB.withOld" ${VERBOSITY}
+        # shellcheck disable=SC2086
+        "$MMSEQS" rmdb "${TMP_PATH}/NEWDB.withOld_h" ${VERBOSITY}
+    else
+        # shellcheck disable=SC2086
+        "$MMSEQS" rmdb "${TMP_PATH}/OLCLUST.withoutDeletedKeys" ${VERBOSITY}
+        # shellcheck disable=SC2086
+        "$MMSEQS" rmdb "${TMP_PATH}/OLCLUST.withoutDeleted" ${VERBOSITY}
+    fi
+
+    # shellcheck disable=SC2086
+    "$MMSEQS" rmdb "${TMP_PATH}/newSeqsHits.swapped" ${VERBOSITY}
+    # shellcheck disable=SC2086
+    "$MMSEQS" rmdb "${TMP_PATH}/newClusters" ${VERBOSITY}
+    # shellcheck disable=SC2086
+    "$MMSEQS" rmdb "${TMP_PATH}/newSeqsHits" ${VERBOSITY}
+    # shellcheck disable=SC2086
+    "$MMSEQS" rmdb "${TMP_PATH}/newSeqsHits.best" ${VERBOSITY}
+    # shellcheck disable=SC2086
+    "$MMSEQS" rmdb "${TMP_PATH}/newSeqsPref" ${VERBOSITY}
+    # shellcheck disable=SC2086
+    "$MMSEQS" rmdb "${TMP_PATH}/toBeClusteredSeparately" ${VERBOSITY}
+    # shellcheck disable=SC2086
+    "$MMSEQS" rmdb "${TMP_PATH}/NEWDB.newSeqs" ${VERBOSITY}
+    # shellcheck disable=SC2086
+    "$MMSEQS" rmdb "${TMP_PATH}/newSeqsHits.swapped.all" ${VERBOSITY}
+    # shellcheck disable=SC2086
+    "$MMSEQS" rmdb "${TMP_PATH}/OLDDB.repSeq" ${VERBOSITY}
+    if [ -f "${TMP_PATH}/OLDDB.repSeq_ss.dbtype" ]; then
+        # shellcheck disable=SC2086
+        "$MMSEQS" rmdb "${TMP_PATH}/OLDDB.repSeq_ss" ${VERBOSITY}
+    fi
+    # shellcheck disable=SC2086
+    "$MMSEQS" rmdb "${TMP_PATH}/updatedClust" ${VERBOSITY}
+
+    rm -rf "${TMP_PATH}/search" "${TMP_PATH}/cluster"
+    rm -f "${TMP_PATH}/structureclusterupdate.sh"
+fi

--- a/data/structureclusterupdate.sh
+++ b/data/structureclusterupdate.sh
@@ -246,19 +246,25 @@ if [ -f "${OLDDB}_ca.dbtype" ] && notExists "${TMP_PATH}/OLDDB.repSeq_ca.dbtype"
         || fail "createsubdb for rep C-alpha sequences died"
 fi
 
+# Select the representative DBs for prefilter and alignment. The GPU ungapped prefilter
+# needs a padded representative DB (makepaddedseqdb), which reassigns rep keys to 0..N-1.
+# Both the prefilter and the structural alignment must run against that same padded
+# keyspace; the resulting rep keys are mapped back to the original keys after swapdb below.
+REPSEQ_SS="${TMP_PATH}/OLDDB.repSeq_ss"
+REPSEQ_ALN="${TMP_PATH}/OLDDB.repSeq"
+if [ "$PREFMODE" = "UNGAPPED" ] && [ -n "${GPU}" ]; then
+    if notExists "${TMP_PATH}/OLDDB.repSeq_pad.dbtype"; then
+        # shellcheck disable=SC2086
+        "$MMSEQS" makepaddedseqdb "${TMP_PATH}/OLDDB.repSeq" "${TMP_PATH}/OLDDB.repSeq_pad" ${THREADS_PAR} \
+            || fail "makepaddedseqdb died"
+    fi
+    REPSEQ_SS="${TMP_PATH}/OLDDB.repSeq_pad_ss"
+    REPSEQ_ALN="${TMP_PATH}/OLDDB.repSeq_pad"
+fi
+
 if notExists "${TMP_PATH}/newSeqsPref.dbtype"; then
     log "=== Prefilter new sequences against cluster representatives"
     if [ "$PREFMODE" = "UNGAPPED" ]; then
-        REPSEQ_SS="${TMP_PATH}/OLDDB.repSeq_ss"
-        if [ -n "${GPU}" ]; then
-            # pad the representative set for the GPU ungapped prefilter
-            if notExists "${TMP_PATH}/OLDDB.repSeq_pad.dbtype"; then
-                # shellcheck disable=SC2086
-                "$MMSEQS" makepaddedseqdb "${TMP_PATH}/OLDDB.repSeq" "${TMP_PATH}/OLDDB.repSeq_pad" ${THREADS_PAR} \
-                    || fail "makepaddedseqdb died"
-            fi
-            REPSEQ_SS="${TMP_PATH}/OLDDB.repSeq_pad_ss"
-        fi
         # shellcheck disable=SC2086
         $RUNNER "$MMSEQS" ungappedprefilter "${TMP_PATH}/NEWDB.newSeqs_ss" "${REPSEQ_SS}" \
             "${TMP_PATH}/newSeqsPref" ${UNGAPPEDPREFILTER_PAR} \
@@ -274,7 +280,7 @@ fi
 if notExists "${TMP_PATH}/newSeqsHits.dbtype"; then
     log "=== Structurally align new sequences against cluster representatives"
     # shellcheck disable=SC2086
-    $RUNNER "$MMSEQS" $ALIGNMENT_ALGO "${TMP_PATH}/NEWDB.newSeqs" "${TMP_PATH}/OLDDB.repSeq" \
+    $RUNNER "$MMSEQS" $ALIGNMENT_ALGO "${TMP_PATH}/NEWDB.newSeqs" "${REPSEQ_ALN}" \
         "${TMP_PATH}/newSeqsPref" "${TMP_PATH}/newSeqsHits" ${ALIGNMENT_PAR} \
         || fail "Structural alignment died"
 fi
@@ -298,6 +304,36 @@ if [ -s "${TMP_PATH}/newSeqsHits.swapped.hasHits" ] && notExists "${TMP_PATH}/ne
     # shellcheck disable=SC2086
     "$MMSEQS" filterdb "${TMP_PATH}/newSeqsHits.swapped.all" "${TMP_PATH}/newSeqsHits.swapped" --trim-to-one-column ${THREADS_PAR} \
         || fail "filterdb died"
+fi
+
+# In GPU mode the prefilter/alignment ran against the padded representative DB, so the
+# swapped DB is keyed by padded rep keys (0..N-1). Map them back to the original rep keys
+# before merging with OLDCLUST. repSeq_pad.lookup is mmseqs lookup format
+# (col1=paddedKey, col2=name, col3=originalKey); use col3 for the remap target.
+# Gated on a one-shot sentinel: renamedbkeys consumes the padded-keyed swapped DB, so a
+# second pass over the already-remapped DB would build an empty map and wipe the data.
+if [ -n "${GPU}" ] && [ "$PREFMODE" = "UNGAPPED" ] \
+        && [ -f "${TMP_PATH}/newSeqsHits.swapped.dbtype" ] \
+        && notExists "${TMP_PATH}/newSeqsHits.swapped.remapped"; then
+    awk 'NR==FNR { o[$1]=$3; next } ($1 in o) { print $1"\t"o[$1] }' \
+        "${TMP_PATH}/OLDDB.repSeq_pad.lookup" "${TMP_PATH}/newSeqsHits.swapped.index" \
+        > "${TMP_PATH}/repSeqPadKeyMap"
+    # shellcheck disable=SC2086
+    "$MMSEQS" renamedbkeys "${TMP_PATH}/repSeqPadKeyMap" "${TMP_PATH}/newSeqsHits.swapped" \
+        "${TMP_PATH}/newSeqsHits.swapped.orig" ${VERBOSITY} \
+        || fail "renamedbkeys padded->original rep keys died"
+    # filterdb wrote newSeqsHits.swapped as ${THREADS} split parts (.0../.N); renamedbkeys
+    # wrote the remapped DB as a single merged file. mvdb overwrites the merged data/index
+    # but leaves the stale pre-remap split parts behind, and DBReader prefers split parts
+    # over the merged file (FileUtil::findDatafiles), so it would read stale data with the
+    # post-remap index. rmdb clears the split parts (it does not touch the .orig sibling).
+    # shellcheck disable=SC2086
+    "$MMSEQS" rmdb "${TMP_PATH}/newSeqsHits.swapped" ${VERBOSITY} \
+        || fail "rmdb stale swapped split parts died"
+    # shellcheck disable=SC2086
+    "$MMSEQS" mvdb "${TMP_PATH}/newSeqsHits.swapped.orig" "${TMP_PATH}/newSeqsHits.swapped" ${VERBOSITY} \
+        || fail "mvdb remapped swapped db died"
+    touch "${TMP_PATH}/newSeqsHits.swapped.remapped"
 fi
 
 UPDATEDCLUST="${TMP_PATH}/updatedClust"

--- a/data/structureclusterupdate.sh
+++ b/data/structureclusterupdate.sh
@@ -30,7 +30,7 @@ log() {
 }
 
 # check number of input variables
-[ "$#" -ne 6 ] && echo "Please provide <i:oldSequenceDB> <i:newSequenceDB> <i:oldClusteringDB> <o:newMappedSequenceDB> <o:newClusteringDB> <o:tmpDir>" && exit 1
+[ "$#" -ne 6 ] && echo "Please provide <i:oldSequenceDB> <i:newSequenceDB> <i:oldClusteringDB> <o:newMappedSequenceDB> <o:newClusteringDB> <tmpDir>" && exit 1
 # check if files exist
 [ ! -f "$1.dbtype" ] && echo "$1.dbtype not found!" && exit 1
 [ ! -f "$2.dbtype" ] && echo "$2.dbtype not found!" && exit 1
@@ -81,9 +81,35 @@ if [ -s "${TMP_PATH}/removedSeqs" ]; then
             # shellcheck disable=SC2086
             "$MMSEQS" concatdbs "$NEWDB" "${TMP_PATH}/OLDDB.removedDb" "${TMP_PATH}/NEWDB.withOld" --preserve-keys --threads 1 ${VERBOSITY} \
                 || fail "concatdbs died"
+        fi
+        if notExists "${TMP_PATH}/NEWDB.withOld_h.dbtype"; then
             # shellcheck disable=SC2086
             "$MMSEQS" concatdbs "${NEWDB}_h" "${TMP_PATH}/OLDDB.removedDb_h" "${TMP_PATH}/NEWDB.withOld_h" --preserve-keys --threads 1 ${VERBOSITY} \
                 || fail "concatdbs died"
+        fi
+        if [ -f "${OLDDB}_ss.dbtype" ] && [ -f "${NEWDB}_ss.dbtype" ]; then
+            if notExists "${TMP_PATH}/OLDDB.removedDb_ss.dbtype"; then
+                # shellcheck disable=SC2086
+                "$MMSEQS" renamedbkeys "${TMP_PATH}/OLDDB.removedMapping" "${OLDDB}_ss" "${TMP_PATH}/OLDDB.removedDb_ss" --subdb-mode 1 ${VERBOSITY} \
+                    || fail "renamedbkeys for 3Di died"
+            fi
+            if notExists "${TMP_PATH}/NEWDB.withOld_ss.dbtype"; then
+                # shellcheck disable=SC2086
+                "$MMSEQS" concatdbs "${NEWDB}_ss" "${TMP_PATH}/OLDDB.removedDb_ss" "${TMP_PATH}/NEWDB.withOld_ss" --preserve-keys --threads 1 ${VERBOSITY} \
+                    || fail "concatdbs for 3Di died"
+            fi
+        fi
+        if [ -f "${OLDDB}_ca.dbtype" ] && [ -f "${NEWDB}_ca.dbtype" ]; then
+            if notExists "${TMP_PATH}/OLDDB.removedDb_ca.dbtype"; then
+                # shellcheck disable=SC2086
+                "$MMSEQS" renamedbkeys "${TMP_PATH}/OLDDB.removedMapping" "${OLDDB}_ca" "${TMP_PATH}/OLDDB.removedDb_ca" --subdb-mode 1 ${VERBOSITY} \
+                    || fail "renamedbkeys for C-alpha died"
+            fi
+            if notExists "${TMP_PATH}/NEWDB.withOld_ca.dbtype"; then
+                # shellcheck disable=SC2086
+                "$MMSEQS" concatdbs "${NEWDB}_ca" "${TMP_PATH}/OLDDB.removedDb_ca" "${TMP_PATH}/NEWDB.withOld_ca" --preserve-keys --threads 1 ${VERBOSITY} \
+                    || fail "concatdbs for C-alpha died"
+            fi
         fi
         NEWDB="${TMP_PATH}/NEWDB.withOld"
 
@@ -92,6 +118,16 @@ if [ -s "${TMP_PATH}/removedSeqs" ]; then
             rm -f "${TMP_PATH}/OLDDB.removedMapping"
             # shellcheck disable=SC2086
             "$MMSEQS" rmdb "${TMP_PATH}/OLDDB.removedDb" ${VERBOSITY}
+            # shellcheck disable=SC2086
+            "$MMSEQS" rmdb "${TMP_PATH}/OLDDB.removedDb_h" ${VERBOSITY}
+            if [ -f "${TMP_PATH}/OLDDB.removedDb_ss.dbtype" ]; then
+                # shellcheck disable=SC2086
+                "$MMSEQS" rmdb "${TMP_PATH}/OLDDB.removedDb_ss" ${VERBOSITY}
+            fi
+            if [ -f "${TMP_PATH}/OLDDB.removedDb_ca.dbtype" ]; then
+                # shellcheck disable=SC2086
+                "$MMSEQS" rmdb "${TMP_PATH}/OLDDB.removedDb_ca" ${VERBOSITY}
+            fi
         fi
     else
         if notExists "${TMP_PATH}/REMOVEDMEMBERS.dbtype"; then
@@ -148,6 +184,11 @@ if [ -f "${NEWDB}_ss.dbtype" ] && notExists "${NEWMAPDB}_ss.dbtype"; then
     "$MMSEQS" renamedbkeys "${TMP_PATH}/newMappingSeqs" "${NEWDB}_ss" "${NEWMAPDB}_ss" ${VERBOSITY} \
         || fail "renamedbkeys for 3Di died"
 fi
+if [ -f "${NEWDB}_ca.dbtype" ] && notExists "${NEWMAPDB}_ca.dbtype"; then
+    # shellcheck disable=SC2086
+    "$MMSEQS" renamedbkeys "${TMP_PATH}/newMappingSeqs" "${NEWDB}_ca" "${NEWMAPDB}_ca" ${VERBOSITY} \
+        || fail "renamedbkeys for C-alpha died"
+fi
 if [ -f "${NEWDB}_h.dbtype" ] && notExists "${NEWMAPDB}_h.dbtype"; then
     # shellcheck disable=SC2086
     "$MMSEQS" renamedbkeys "${TMP_PATH}/newMappingSeqs" "${NEWDB}_h" "${NEWMAPDB}_h" ${VERBOSITY} \
@@ -175,6 +216,13 @@ if [ -f "${NEWDB}_ss.dbtype" ] && notExists "${TMP_PATH}/NEWDB.newSeqs_ss.dbtype
         || fail "createsubdb for 3Di died"
 fi
 
+if [ -f "${NEWDB}_ca.dbtype" ] && notExists "${TMP_PATH}/NEWDB.newSeqs_ca.dbtype"; then
+    log "=== Filter out new from old C-alpha coordinates"
+    # shellcheck disable=SC2086
+    "$MMSEQS" createsubdb "${NEWSEQ}" "${NEWDB}_ca" "${TMP_PATH}/NEWDB.newSeqs_ca" ${VERBOSITY} --subdb-mode 1 \
+        || fail "createsubdb for C-alpha died"
+fi
+
 if notExists "${TMP_PATH}/OLDDB.repSeq.dbtype"; then
     log "=== Extract representative AA sequences"
     # Use createsubdb (not result2repseq): afdb50_clu members are keyed on afdb50_seq (241M),
@@ -191,10 +239,17 @@ if [ -f "${OLDDB}_ss.dbtype" ] && notExists "${TMP_PATH}/OLDDB.repSeq_ss.dbtype"
         || fail "createsubdb for rep 3Di sequences died"
 fi
 
+if [ -f "${OLDDB}_ca.dbtype" ] && notExists "${TMP_PATH}/OLDDB.repSeq_ca.dbtype"; then
+    log "=== Extract representative C-alpha coordinates"
+    # shellcheck disable=SC2086
+    "$MMSEQS" createsubdb "$OLDCLUST" "${OLDDB}_ca" "${TMP_PATH}/OLDDB.repSeq_ca" --subdb-mode 1 ${VERBOSITY} \
+        || fail "createsubdb for rep C-alpha sequences died"
+fi
+
 if notExists "${TMP_PATH}/newSeqsPref.dbtype"; then
     log "=== Prefilter new sequences against cluster representatives"
     # shellcheck disable=SC2086
-    $RUNNER "$MMSEQS" prefilter "${TMP_PATH}/NEWDB.newSeqs" "${TMP_PATH}/OLDDB.repSeq" \
+    $RUNNER "$MMSEQS" prefilter "${TMP_PATH}/NEWDB.newSeqs_ss" "${TMP_PATH}/OLDDB.repSeq_ss" \
         "${TMP_PATH}/newSeqsPref" ${PREFILTER_PAR} \
         || fail "Prefilter died"
 fi
@@ -256,7 +311,7 @@ if notExists "${TMP_PATH}/newClusters.dbtype" && [ -s "${TMP_PATH}/toBeClustered
 fi
 
 if [ -f "${TMP_PATH}/newClusters.dbtype" ]; then
-    if notExists "$NEWCLUST"; then
+    if notExists "${NEWCLUST}.dbtype"; then
         log "=== Merge updated clustering with new clusters"
         # shellcheck disable=SC2086
         "$MMSEQS" concatdbs "${UPDATEDCLUST}" "${TMP_PATH}/newClusters" "$NEWCLUST" --preserve-keys ${THREADS_PAR} \
@@ -277,11 +332,23 @@ if [ -n "$REMOVE_TMP" ]; then
         "$MMSEQS" rmdb "${TMP_PATH}/NEWDB.withOld" ${VERBOSITY}
         # shellcheck disable=SC2086
         "$MMSEQS" rmdb "${TMP_PATH}/NEWDB.withOld_h" ${VERBOSITY}
+        if [ -f "${TMP_PATH}/NEWDB.withOld_ss.dbtype" ]; then
+            # shellcheck disable=SC2086
+            "$MMSEQS" rmdb "${TMP_PATH}/NEWDB.withOld_ss" ${VERBOSITY}
+        fi
+        if [ -f "${TMP_PATH}/NEWDB.withOld_ca.dbtype" ]; then
+            # shellcheck disable=SC2086
+            "$MMSEQS" rmdb "${TMP_PATH}/NEWDB.withOld_ca" ${VERBOSITY}
+        fi
     else
-        # shellcheck disable=SC2086
-        "$MMSEQS" rmdb "${TMP_PATH}/OLCLUST.withoutDeletedKeys" ${VERBOSITY}
-        # shellcheck disable=SC2086
-        "$MMSEQS" rmdb "${TMP_PATH}/OLCLUST.withoutDeleted" ${VERBOSITY}
+        if [ -f "${TMP_PATH}/OLCLUST.withoutDeletedKeys.dbtype" ]; then
+            # shellcheck disable=SC2086
+            "$MMSEQS" rmdb "${TMP_PATH}/OLCLUST.withoutDeletedKeys" ${VERBOSITY}
+        fi
+        if [ -f "${TMP_PATH}/OLCLUST.withoutDeleted.dbtype" ]; then
+            # shellcheck disable=SC2086
+            "$MMSEQS" rmdb "${TMP_PATH}/OLCLUST.withoutDeleted" ${VERBOSITY}
+        fi
     fi
 
     # shellcheck disable=SC2086
@@ -298,6 +365,14 @@ if [ -n "$REMOVE_TMP" ]; then
     "$MMSEQS" rmdb "${TMP_PATH}/toBeClusteredSeparately" ${VERBOSITY}
     # shellcheck disable=SC2086
     "$MMSEQS" rmdb "${TMP_PATH}/NEWDB.newSeqs" ${VERBOSITY}
+    if [ -f "${TMP_PATH}/NEWDB.newSeqs_ss.dbtype" ]; then
+        # shellcheck disable=SC2086
+        "$MMSEQS" rmdb "${TMP_PATH}/NEWDB.newSeqs_ss" ${VERBOSITY}
+    fi
+    if [ -f "${TMP_PATH}/NEWDB.newSeqs_ca.dbtype" ]; then
+        # shellcheck disable=SC2086
+        "$MMSEQS" rmdb "${TMP_PATH}/NEWDB.newSeqs_ca" ${VERBOSITY}
+    fi
     # shellcheck disable=SC2086
     "$MMSEQS" rmdb "${TMP_PATH}/newSeqsHits.swapped.all" ${VERBOSITY}
     # shellcheck disable=SC2086
@@ -305,6 +380,10 @@ if [ -n "$REMOVE_TMP" ]; then
     if [ -f "${TMP_PATH}/OLDDB.repSeq_ss.dbtype" ]; then
         # shellcheck disable=SC2086
         "$MMSEQS" rmdb "${TMP_PATH}/OLDDB.repSeq_ss" ${VERBOSITY}
+    fi
+    if [ -f "${TMP_PATH}/OLDDB.repSeq_ca.dbtype" ]; then
+        # shellcheck disable=SC2086
+        "$MMSEQS" rmdb "${TMP_PATH}/OLDDB.repSeq_ca" ${VERBOSITY}
     fi
     # shellcheck disable=SC2086
     "$MMSEQS" rmdb "${TMP_PATH}/updatedClust" ${VERBOSITY}

--- a/data/structureclusterupdate.sh
+++ b/data/structureclusterupdate.sh
@@ -248,10 +248,27 @@ fi
 
 if notExists "${TMP_PATH}/newSeqsPref.dbtype"; then
     log "=== Prefilter new sequences against cluster representatives"
-    # shellcheck disable=SC2086
-    $RUNNER "$MMSEQS" prefilter "${TMP_PATH}/NEWDB.newSeqs_ss" "${TMP_PATH}/OLDDB.repSeq_ss" \
-        "${TMP_PATH}/newSeqsPref" ${PREFILTER_PAR} \
-        || fail "Prefilter died"
+    if [ "$PREFMODE" = "UNGAPPED" ]; then
+        REPSEQ_SS="${TMP_PATH}/OLDDB.repSeq_ss"
+        if [ -n "${GPU}" ]; then
+            # pad the representative set for the GPU ungapped prefilter
+            if notExists "${TMP_PATH}/OLDDB.repSeq_pad.dbtype"; then
+                # shellcheck disable=SC2086
+                "$MMSEQS" makepaddedseqdb "${TMP_PATH}/OLDDB.repSeq" "${TMP_PATH}/OLDDB.repSeq_pad" ${THREADS_PAR} \
+                    || fail "makepaddedseqdb died"
+            fi
+            REPSEQ_SS="${TMP_PATH}/OLDDB.repSeq_pad_ss"
+        fi
+        # shellcheck disable=SC2086
+        $RUNNER "$MMSEQS" ungappedprefilter "${TMP_PATH}/NEWDB.newSeqs_ss" "${REPSEQ_SS}" \
+            "${TMP_PATH}/newSeqsPref" ${UNGAPPEDPREFILTER_PAR} \
+            || fail "Ungapped prefilter died"
+    else
+        # shellcheck disable=SC2086
+        $RUNNER "$MMSEQS" prefilter "${TMP_PATH}/NEWDB.newSeqs_ss" "${TMP_PATH}/OLDDB.repSeq_ss" \
+            "${TMP_PATH}/newSeqsPref" ${PREFILTER_PAR} \
+            || fail "Prefilter died"
+    fi
 fi
 
 if notExists "${TMP_PATH}/newSeqsHits.dbtype"; then

--- a/src/FoldseekBase.cpp
+++ b/src/FoldseekBase.cpp
@@ -158,6 +158,23 @@ std::vector<Command> foldseekCommands = {
                 CITATION_FOLDSEEK|CITATION_MMSEQS2, {{"sequenceDB", DbType::ACCESS_MODE_INPUT, DbType::NEED_DATA, &DbValidator::sequenceDb },
                                            {"clusterDB", DbType::ACCESS_MODE_OUTPUT, DbType::NEED_DATA, &DbValidator::clusterDb },
                                            {"tmpDir", DbType::ACCESS_MODE_OUTPUT, DbType::NEED_DATA, &DbValidator::directory }}},
+        {"structureclusterupdate", structureclusterupdate, &localPar.structureclusterworkflow, COMMAND_MAIN,
+                "Update structure clustering with new sequences using structural alignment",
+                "# Extend an existing structural clustering with new sequences\n"
+                "# Step 1: concatenate old and new sequence DBs\n"
+                "foldseek concatdbs oldSeqDB newSeqDB allSeqDB\n"
+                "foldseek concatdbs oldSeqDB_h newSeqDB_h allSeqDB_h\n\n"
+                "# Step 2: run structural cluster update\n"
+                "foldseek structureclusterupdate oldSeqDB allSeqDB oldClusterDB newMappedDB newClusterDB tmp\n",
+                "Martin Steinegger <martin.steinegger@snu.ac.kr>",
+                "<i:oldSequenceDB> <i:newSequenceDB> <i:oldClustResultDB> <o:newMappedSequenceDB> <o:newClustResultDB> <tmpDir>",
+                CITATION_FOLDSEEK,
+                {{"oldSequenceDB",    DbType::ACCESS_MODE_INPUT,  DbType::NEED_DATA|DbType::NEED_HEADER|DbType::NEED_LOOKUP, &DbValidator::sequenceDb},
+                 {"newSequenceDB",    DbType::ACCESS_MODE_INPUT,  DbType::NEED_DATA|DbType::NEED_HEADER|DbType::NEED_LOOKUP, &DbValidator::sequenceDb},
+                 {"oldClustResultDB", DbType::ACCESS_MODE_INPUT,  DbType::NEED_DATA, &DbValidator::clusterDb},
+                 {"newMappedSeqDB",   DbType::ACCESS_MODE_OUTPUT, DbType::NEED_DATA, &DbValidator::sequenceDb},
+                 {"newClustResultDB", DbType::ACCESS_MODE_OUTPUT, DbType::NEED_DATA, &DbValidator::clusterDb},
+                 {"tmpDir",           DbType::ACCESS_MODE_OUTPUT, DbType::NEED_DATA, &DbValidator::directory}}},
 
 
 

--- a/src/FoldseekBase.cpp
+++ b/src/FoldseekBase.cpp
@@ -158,12 +158,14 @@ std::vector<Command> foldseekCommands = {
                 CITATION_FOLDSEEK|CITATION_MMSEQS2, {{"sequenceDB", DbType::ACCESS_MODE_INPUT, DbType::NEED_DATA, &DbValidator::sequenceDb },
                                            {"clusterDB", DbType::ACCESS_MODE_OUTPUT, DbType::NEED_DATA, &DbValidator::clusterDb },
                                            {"tmpDir", DbType::ACCESS_MODE_OUTPUT, DbType::NEED_DATA, &DbValidator::directory }}},
-        {"structureclusterupdate", structureclusterupdate, &localPar.structureclusterworkflow, COMMAND_MAIN,
+        {"structureclusterupdate", structureclusterupdate, &localPar.structureclusterupdate, COMMAND_MAIN,
                 "Update structure clustering with new sequences using structural alignment",
                 "# Extend an existing structural clustering with new sequences\n"
-                "# Step 1: concatenate old and new sequence DBs\n"
+                "# Step 1: concatenate old and new sequence DBs (all sidecars)\n"
                 "foldseek concatdbs oldSeqDB newSeqDB allSeqDB\n"
-                "foldseek concatdbs oldSeqDB_h newSeqDB_h allSeqDB_h\n\n"
+                "foldseek concatdbs oldSeqDB_h newSeqDB_h allSeqDB_h\n"
+                "foldseek concatdbs oldSeqDB_ss newSeqDB_ss allSeqDB_ss\n"
+                "foldseek concatdbs oldSeqDB_ca newSeqDB_ca allSeqDB_ca\n\n"
                 "# Step 2: run structural cluster update\n"
                 "foldseek structureclusterupdate oldSeqDB allSeqDB oldClusterDB newMappedDB newClusterDB tmp\n",
                 "Martin Steinegger <martin.steinegger@snu.ac.kr>",

--- a/src/LocalCommandDeclarations.h
+++ b/src/LocalCommandDeclarations.h
@@ -7,6 +7,7 @@ extern int structcreatedb(int argc, const char **argv, const Command& command);
 extern int structuresearch(int argc, const char** argv, const Command &command);
 extern int structureindex(int argc, const char** argv, const Command &command);
 extern int structurecluster(int argc, const char** argv, const Command &command);
+extern int structureclusterupdate(int argc, const char** argv, const Command &command);
 extern int easystructuresearch(int argc, const char** argv, const Command &command);
 extern int easystructurecluster(int argc, const char** argv, const Command &command);
 extern int tmalign(int argc, const char** argv, const Command &command);

--- a/src/commons/LocalParameters.cpp
+++ b/src/commons/LocalParameters.cpp
@@ -287,6 +287,7 @@ LocalParameters::LocalParameters() :
 
     structureclusterupdate = structureclusterworkflow;
     structureclusterupdate.push_back(&PARAM_RECOVER_DELETED);
+    structureclusterupdate = combineList(structureclusterupdate, ungappedprefilter);
 
     easystructureclusterworkflow = combineList(structureclusterworkflow, structurecreatedb);
     easystructureclusterworkflow = combineList(easystructureclusterworkflow, result2repseq);

--- a/src/commons/LocalParameters.cpp
+++ b/src/commons/LocalParameters.cpp
@@ -285,6 +285,9 @@ LocalParameters::LocalParameters() :
     structureclusterworkflow.push_back(&PARAM_RUNNER);
     structureclusterworkflow = combineList(structureclusterworkflow, linclustworkflow);
 
+    structureclusterupdate = structureclusterworkflow;
+    structureclusterupdate.push_back(&PARAM_RECOVER_DELETED);
+
     easystructureclusterworkflow = combineList(structureclusterworkflow, structurecreatedb);
     easystructureclusterworkflow = combineList(easystructureclusterworkflow, result2repseq);
 

--- a/src/commons/LocalParameters.h
+++ b/src/commons/LocalParameters.h
@@ -117,6 +117,7 @@ public:
     std::vector<MMseqsParameter *> structurerescorediagonal;
     std::vector<MMseqsParameter *> structuresearchworkflow;
     std::vector<MMseqsParameter *> structureclusterworkflow;
+    std::vector<MMseqsParameter *> structureclusterupdate;
     std::vector<MMseqsParameter *> databases;
     std::vector<MMseqsParameter *> samplemulambda;
     std::vector<MMseqsParameter *> easystructuresearchworkflow;

--- a/src/workflow/CMakeLists.txt
+++ b/src/workflow/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(workflow_source_files
         workflow/StructureCluster.cpp
+        workflow/StructureClusterUpdate.cpp
         workflow/StructureIndex.cpp
         workflow/StructureSearch.cpp
         workflow/StructureRbh.cpp

--- a/src/workflow/StructureClusterUpdate.cpp
+++ b/src/workflow/StructureClusterUpdate.cpp
@@ -1,0 +1,94 @@
+#include "Parameters.h"
+#include "Util.h"
+#include "CommandCaller.h"
+#include "Debug.h"
+#include "FileUtil.h"
+#include "structureclusterupdate.sh.h"
+#include <cassert>
+#include "LocalParameters.h"
+
+void setStructureClusterUpdateDefaults(LocalParameters *p) {
+    p->covThr = 0.8;
+    p->evalThr = 0.001;
+    p->sortByStructureBits = 0;
+    p->alignmentMode = Parameters::ALIGNMENT_MODE_SCORE_COV_SEQID;
+    p->compBiasCorrection = 0;
+}
+
+void setStructureClusterUpdateMustPassAlong(LocalParameters *p) {
+    p->PARAM_ALIGNMENT_MODE.wasSet = true;
+}
+
+int structureclusterupdate(int argc, const char **argv, const Command& command) {
+    LocalParameters &par = LocalParameters::getLocalInstance();
+    setStructureClusterUpdateDefaults(&par);
+    par.PARAM_ADD_BACKTRACE.addCategory(MMseqsParameter::COMMAND_EXPERT);
+    par.PARAM_ALT_ALIGNMENT.addCategory(MMseqsParameter::COMMAND_EXPERT);
+    par.PARAM_RESCORE_MODE.addCategory(MMseqsParameter::COMMAND_EXPERT);
+    par.PARAM_MAX_REJECTED.addCategory(MMseqsParameter::COMMAND_EXPERT);
+    par.PARAM_MAX_ACCEPT.addCategory(MMseqsParameter::COMMAND_EXPERT);
+    par.PARAM_KMER_PER_SEQ_SCALE.addCategory(MMseqsParameter::COMMAND_EXPERT);
+    par.PARAM_KMER_PER_SEQ.addCategory(MMseqsParameter::COMMAND_EXPERT);
+    par.PARAM_START_SENS.addCategory(MMseqsParameter::COMMAND_EXPERT);
+    par.PARAM_SENS_STEPS.addCategory(MMseqsParameter::COMMAND_EXPERT);
+    par.PARAM_CLUSTER_REASSIGN.addCategory(MMseqsParameter::COMMAND_EXPERT);
+    par.PARAM_INCLUDE_ONLY_EXTENDABLE.addCategory(MMseqsParameter::COMMAND_EXPERT);
+    par.PARAM_NUM_ITERATIONS.addCategory(MMseqsParameter::COMMAND_EXPERT);
+    par.PARAM_COMPRESSED.removeCategory(MMseqsParameter::COMMAND_EXPERT);
+    par.PARAM_THREADS.removeCategory(MMseqsParameter::COMMAND_EXPERT);
+    par.PARAM_V.removeCategory(MMseqsParameter::COMMAND_EXPERT);
+
+    par.parseParameters(argc, argv, command, true, 0, 0);
+    setStructureClusterUpdateMustPassAlong(&par);
+
+    std::string tmpDir = par.db6;
+    std::string hash = SSTR(par.hashParameter(command.databases, par.filenames, par.clusterUpdate));
+    if (par.reuseLatest) {
+        hash = FileUtil::getHashFromSymLink(tmpDir + "/latest");
+    }
+    tmpDir = FileUtil::createTemporaryDirectory(tmpDir, hash);
+    par.filenames.pop_back();
+    par.filenames.push_back(tmpDir);
+
+    CommandCaller cmd;
+    cmd.addVariable("REMOVE_TMP", par.removeTmpFiles ? "TRUE" : NULL);
+    cmd.addVariable("RECOVER_DELETED", par.recoverDeleted ? "TRUE" : NULL);
+    cmd.addVariable("RUNNER", par.runner.c_str());
+    cmd.addVariable("VERBOSITY", par.createParameterString(par.onlyverbosity).c_str());
+
+    int oldVerbosity = par.verbosity;
+    par.verbosity = std::min(par.verbosity, 1);
+    cmd.addVariable("NOWARNINGS_PAR", par.createParameterString(par.onlyverbosity).c_str());
+    par.verbosity = oldVerbosity;
+
+    cmd.addVariable("THREADS_PAR", par.createParameterString(par.onlythreads).c_str());
+    cmd.addVariable("DIFF_PAR", par.createParameterString(par.diff).c_str());
+    cmd.addVariable("RESULT2REPSEQ_PAR", par.createParameterString(par.result2repseq).c_str());
+    cmd.addVariable("CLUST_PAR", par.createParameterString(par.clusterworkflow, true).c_str());
+
+    // structural alignment algorithm and parameters
+    std::string alnParam;
+    if (par.alignmentType == LocalParameters::ALIGNMENT_TYPE_TMALIGN) {
+        cmd.addVariable("ALIGNMENT_ALGO", "tmalign");
+        alnParam = par.createParameterString(par.tmalign);
+    } else if (par.alignmentType == LocalParameters::ALIGNMENT_TYPE_3DI_AA ||
+               par.alignmentType == LocalParameters::ALIGNMENT_TYPE_3DI) {
+        cmd.addVariable("ALIGNMENT_ALGO", "structurealign");
+        alnParam = par.createParameterString(par.structurealign);
+    } else {
+        Debug(Debug::ERROR) << "Unknown alignment type: " << par.alignmentType << "\n";
+        EXIT(EXIT_FAILURE);
+    }
+    cmd.addVariable("ALIGNMENT_PAR", alnParam.c_str());
+
+    // prefilter uses 3Di k-mer lookup
+    cmd.addVariable("PREFILTER_PAR", par.createParameterString(par.prefilter).c_str());
+
+    std::string program = tmpDir + "/structureclusterupdate.sh";
+    FileUtil::writeFile(program, structureclusterupdate_sh, structureclusterupdate_sh_len);
+    cmd.execProgram(program.c_str(), par.filenames);
+
+    // Unreachable
+    assert(false);
+    return EXIT_FAILURE;
+}

--- a/src/workflow/StructureClusterUpdate.cpp
+++ b/src/workflow/StructureClusterUpdate.cpp
@@ -5,6 +5,7 @@
 #include "FileUtil.h"
 #include "structureclusterupdate.sh.h"
 #include <cassert>
+#include <limits>
 #include "LocalParameters.h"
 
 void setStructureClusterUpdateDefaults(LocalParameters *p) {
@@ -82,6 +83,28 @@ int structureclusterupdate(int argc, const char **argv, const Command& command) 
 
     // prefilter uses 3Di k-mer lookup
     cmd.addVariable("PREFILTER_PAR", par.createParameterString(par.prefilter).c_str());
+
+    double prevEvalueThr = par.evalThr;
+    par.evalThr = std::numeric_limits<double>::max();
+    cmd.addVariable("UNGAPPEDPREFILTER_PAR", par.createParameterString(par.ungappedprefilter).c_str());
+    par.evalThr = prevEvalueThr;
+
+    // GPU can only use the ungapped prefilter
+    if (par.gpu == 1 && par.PARAM_PREF_MODE.wasSet == false) {
+        par.prefMode = Parameters::PREF_MODE_UNGAPPED;
+    }
+    switch (par.prefMode) {
+        case LocalParameters::PREF_MODE_KMER:
+            cmd.addVariable("PREFMODE", "KMER");
+            break;
+        case LocalParameters::PREF_MODE_UNGAPPED:
+            cmd.addVariable("PREFMODE", "UNGAPPED");
+            break;
+        case LocalParameters::PREF_MODE_EXHAUSTIVE:
+            cmd.addVariable("PREFMODE", "EXHAUSTIVE");
+            break;
+    }
+    cmd.addVariable("GPU", par.gpu ? "1" : NULL);
 
     std::string program = tmpDir + "/structureclusterupdate.sh";
     FileUtil::writeFile(program, structureclusterupdate_sh, structureclusterupdate_sh_len);

--- a/src/workflow/StructureClusterUpdate.cpp
+++ b/src/workflow/StructureClusterUpdate.cpp
@@ -42,7 +42,7 @@ int structureclusterupdate(int argc, const char **argv, const Command& command) 
     setStructureClusterUpdateMustPassAlong(&par);
 
     std::string tmpDir = par.db6;
-    std::string hash = SSTR(par.hashParameter(command.databases, par.filenames, par.clusterUpdate));
+    std::string hash = SSTR(par.hashParameter(command.databases, par.filenames, par.structureclusterupdate));
     if (par.reuseLatest) {
         hash = FileUtil::getHashFromSymLink(tmpDir + "/latest");
     }
@@ -63,7 +63,6 @@ int structureclusterupdate(int argc, const char **argv, const Command& command) 
 
     cmd.addVariable("THREADS_PAR", par.createParameterString(par.onlythreads).c_str());
     cmd.addVariable("DIFF_PAR", par.createParameterString(par.diff).c_str());
-    cmd.addVariable("RESULT2REPSEQ_PAR", par.createParameterString(par.result2repseq).c_str());
     cmd.addVariable("CLUST_PAR", par.createParameterString(par.clusterworkflow, true).c_str());
 
     // structural alignment algorithm and parameters


### PR DESCRIPTION
This PR adds `structureclusterupdate`, an incremental update workflow for
structural cluster databases. Given an existing cluster database and a new
(larger) sequence database containing additional structures, it efficiently
updates the cluster assignments without re-running a full clustering from
scratch.

## Approach

Uses `diffseqdbs` to partition sequences into three groups by integer key:
- **mappingSeqs** — sequences present in both old and new DB: cluster
  representatives are remapped to new key space via `renamedbkeys`
- **newSeqs** — sequences only in new DB: searched against existing cluster
  representatives with structural alignment (`structurealign`), then assigned
  or seeded into new clusters
- **removedSeqs** — sequences only in old DB: pruned from cluster assignments
  (or re-appended with new keys when `RECOVER_DELETED=1`)

All prefiltering uses the 3Di alphabet (`--seed-sub-mat aa:3di.out`) and
alignment uses `structurealign`, so the update is fully structure-based
throughout.