### PR TITLE
Fix GemmiToFoldcomp and structcreatedb to handle CB atoms

### DIFF
--- a/src/strucclustutils/GemmiWrapper.cpp
+++ b/src/strucclustutils/GemmiWrapper.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 #include <cstdio>
 #include <cstring>
+#include <cmath>
 #include <limits>
 #include <sys/stat.h>
 
@@ -911,7 +912,7 @@ bool GemmiToFoldcomp(
     }
 
     std::vector<AtomCoordinate> chainAtoms;
-    chainAtoms.reserve((end - start) * 3);
+    chainAtoms.reserve((end - start) * 4);
 
     std::string chainName = gw.chainNames[ci];
     int serial = gw.chainStartSerial[ci];
@@ -921,7 +922,10 @@ bool GemmiToFoldcomp(
         chainAtoms.emplace_back("N", resName, chainName, serial++, resid, gw.n[r].x, gw.n[r].y, gw.n[r].z, 0.0f, 0.0f);
         chainAtoms.emplace_back("CA", resName, chainName, serial++, resid, gw.ca[r].x, gw.ca[r].y, gw.ca[r].z, 0.0f, gw.ca_bfactor[r]);
         chainAtoms.emplace_back("C", resName, chainName, serial++, resid, gw.c[r].x, gw.c[r].y, gw.c[r].z, 0.0f, 0.0f);
-        // chainAtoms.emplace_back("CB", resName, chainName, serial++, resid, gw.cb[r].x, gw.cb[r].y, gw.cb[r].z, 0.0f, 0.0f);
+        // glycine has no CB; cb is also NaN whenever the CB atom is absent from the input
+        if (std::isnan(gw.cb[r].x) == false) {
+            chainAtoms.emplace_back("CB", resName, chainName, serial++, resid, gw.cb[r].x, gw.cb[r].y, gw.cb[r].z, 0.0f, 0.0f);
+        }
     }
 
     if (chainAtoms.empty()) {

--- a/src/strucclustutils/structcreatedb.cpp
+++ b/src/strucclustutils/structcreatedb.cpp
@@ -482,6 +482,7 @@ writeStructureEntry(SubstitutionMatrix & mat, GemmiWrapper & readStructure, Stru
         size_t chainStart = readStructure.chain[ch].first;
         size_t chainEnd = readStructure.chain[ch].second;
         size_t chainLen = chainEnd - chainStart;
+        bool foldcompWritten = false;
         header.clear();
         if (par.dbExtractionMode == LocalParameters::DB_EXTRACT_MODE_CHAIN) {
             if (chainLen <= 3) {
@@ -515,6 +516,14 @@ writeStructureEntry(SubstitutionMatrix & mat, GemmiWrapper & readStructure, Stru
                                         &readStructure.ami[chainStart],
                                         chainLen);
 
+            }
+
+            // Run before structure2states: that call replaces cb with the 3Di virtual center in place
+            if (foldcompWriter != NULL) {
+                std::string foldcompStr;
+                GemmiToFoldcomp(readStructure, ch, foldcompStr);
+                foldcompWriter->writeData(foldcompStr.c_str(), foldcompStr.size(), dbKey, thread_idx, false);
+                foldcompWritten = true;
             }
             char * states = structureTo3Di.structure2states(&readStructure.ca[chainStart],
                                                             &readStructure.n[chainStart],
@@ -622,7 +631,10 @@ writeStructureEntry(SubstitutionMatrix & mat, GemmiWrapper & readStructure, Stru
             mappingWriter->writeData(taxId.c_str(), taxId.size(), dbKey, thread_idx, false);
         }
 
-        if (foldcompWriter != NULL) {
+        // interface extraction mode does not reach the call above, so it still
+        // writes here. Its cb is untouched by structure2states, which runs on
+        // local copies in compute3DiInterfaces.
+        if (foldcompWriter != NULL && foldcompWritten == false) {
             std::string foldcompStr;
             GemmiToFoldcomp(readStructure, ch, foldcompStr);
             foldcompWriter->writeData(foldcompStr.c_str(), foldcompStr.size(), dbKey, thread_idx, false);


### PR DESCRIPTION
## Store real C-beta in the foldcomp (`_fcz`) database

The CB line in `GemmiToFoldcomp` was commented out. Enabling it alone doesn't work: the call sits after `structure2states`, which overwrites `readStructure.cb` in place with the 3Di virtual center.

Moves the write above `structure2states` in chain mode, skips glycine via `std::isnan(gw.cb[r].x)`, keeps the old call site for interface mode.