### PR TITLE
min-aligned-chains always works

### DIFF
--- a/src/strucclustutils/scoremultimer.cpp
+++ b/src/strucclustutils/scoremultimer.cpp
@@ -1318,6 +1318,10 @@ int scoremultimer(int argc, const char **argv, const Command &command) {
                     unsigned int & qKey = qChainKeys[qChainKeyIdx];
                     for (unsigned int assignmentId = 0; assignmentId < assignments.size(); assignmentId++){
                         Assignment &assignment = assignments[assignmentId];
+                        // --min-aligned-chains is applied even without the filtering parameters
+                        if (assignment.chainToChainResults.size() < (size_t)par.minAlignedChains) {
+                            continue;
+                        }
                         currentResultToWrite.clear();
                         assignment.getChainToChainResult(qKey, currentResultToWrite);
                         if (currentResultToWrite.empty()) {


### PR DESCRIPTION
min-aligned-chains didn't work when it's not in filtering loop.
Now it works with default 2